### PR TITLE
Removed unneeded init value

### DIFF
--- a/profile/nodedef/nodedefs.xml
+++ b/profile/nodedef/nodedefs.xml
@@ -65,7 +65,7 @@
       <sends />
       <accepts>
         <cmd id="START">
-          <p id="" editor="minutes" init="2" />
+          <p id="" editor="minutes" />
         </cmd>
         <cmd id="QUERY" />
       </accepts>


### PR DESCRIPTION
Removed init value as it was not a status-id.  Change needed as UD Mobile apps will not show this control if init can not be matched.